### PR TITLE
Using :: to avoid autoload issues

### DIFF
--- a/lib/sanitize/rails/railtie.rb
+++ b/lib/sanitize/rails/railtie.rb
@@ -2,14 +2,14 @@ module Sanitize::Rails
 
   class Railtie < ::Rails::Railtie
     initializer 'sanitize-rails.insert_into_action_view' do
-      ActiveSupport.on_load :action_view do
-        ActionView::Helpers::SanitizeHelper.instance_eval { include Sanitize::Rails::ActionView }
+      ::ActiveSupport.on_load :action_view do
+        ::ActionView::Helpers::SanitizeHelper.instance_eval { include Sanitize::Rails::ActionView }
       end
     end
 
     initializer 'sanitize-rails.insert_into_active_record' do
-      ActiveSupport.on_load :active_record do
-        ActiveRecord::Base.extend Sanitize::Rails::ActiveRecord
+      ::ActiveSupport.on_load :active_record do
+        ::ActiveRecord::Base.extend Sanitize::Rails::ActiveRecord
       end
     end
 


### PR DESCRIPTION
With the split and autoload the railtie code causes autoload to fail when resolving const `ActionView::Helpers::SanitizeHelper`. I've added the `::` operator to all rails classes to avoid future issues
