### PR TITLE
optional skip escaping html entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ an initializer, say `config/initializers/sanitizer.rb`:
       ...
     )
 
+You may pass `skip_escaping_entities: true` if you don't want to escape
+html entities. Example: `Hello & World` will not be changed to
+`Hello &amp; World`
+
 Check out the [example][] in the `example/` directory.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ an initializer, say `config/initializers/sanitizer.rb`:
       ...
     )
 
-You may pass `skip_escaping_entities: true` if you don't want to escape
+You may pass `escape_entities: false` if you don't want to escape
 html entities. Example: `Hello & World` will not be changed to
 `Hello &amp; World`
 

--- a/lib/sanitize/rails.rb
+++ b/lib/sanitize/rails.rb
@@ -8,6 +8,7 @@
 # MIT License
 #
 require 'sanitize'
+require 'htmlentities'
 require 'sanitize/rails/railtie' if defined? Rails
 
 module Sanitize::Rails

--- a/lib/sanitize/rails/engine.rb
+++ b/lib/sanitize/rails/engine.rb
@@ -17,7 +17,7 @@ module Sanitize::Rails
           :elements   => ::ActionView::Base.sanitized_allowed_tags.to_a,
           :attributes => { :all => ::ActionView::Base.sanitized_allowed_attributes.to_a},
           :protocols  => { :all => ::ActionView::Base.sanitized_allowed_protocols.to_a },
-          :skip_escaping_entities => false
+          :escape_entities => true
         }
       rescue
         warn "ActionView not available, falling back to Sanitize's BASIC config"
@@ -63,9 +63,13 @@ module Sanitize::Rails
 
     private
 
+    def escape_entities
+      @@config[:escape_entities].nil? ? true : @@config[:escape_entities]
+    end
+
     def cleaned_fragment(string)
       result = cleaner.fragment(string)
-      result = coder.decode(result) if @@config[:skip_escaping_entities]
+      result = coder.decode(result) unless escape_entities
       result
     end
   end

--- a/lib/sanitize/rails/engine.rb
+++ b/lib/sanitize/rails/engine.rb
@@ -16,13 +16,18 @@ module Sanitize::Rails
         {
           :elements   => ::ActionView::Base.sanitized_allowed_tags.to_a,
           :attributes => { :all => ::ActionView::Base.sanitized_allowed_attributes.to_a},
-          :protocols  => { :all => ::ActionView::Base.sanitized_allowed_protocols.to_a }
+          :protocols  => { :all => ::ActionView::Base.sanitized_allowed_protocols.to_a },
+          :skip_escaping_entities => false
         }
       rescue
         warn "ActionView not available, falling back to Sanitize's BASIC config"
         ::Sanitize::Config::BASIC
       end
       @sanitizer ||= ::Sanitize.new(@@config)
+    end
+
+    def coder
+      @coder ||= HTMLEntities.new
     end
 
     # Returns a copy of the given `string` after sanitizing it and marking it
@@ -32,14 +37,14 @@ module Sanitize::Rails
     # means that text passed through `Sanitize::Rails::Engine.clean`
     # will not be escaped by ActionView's XSS filtering utilities.
     def clean(string)
-      ::ActiveSupport::SafeBuffer.new cleaner.fragment(string)
+      ::ActiveSupport::SafeBuffer.new cleaned_fragment(string)
     end
 
     # Sanitizes the given `string` in place and does NOT mark it as `html_safe`
     #
     def clean!(string)
       return '' if string.nil?
-      string.replace cleaner.fragment(string)
+      string.replace cleaned_fragment(string)
     end
 
     def callback_for(options) #:nodoc:
@@ -54,6 +59,14 @@ module Sanitize::Rails
 
     def method_for(fields) #:nodoc:
       "sanitize_#{fields.join('_')}".intern
+    end
+
+    private
+
+    def cleaned_fragment(string)
+      result = cleaner.fragment(string)
+      result = coder.decode(result) if @@config[:skip_escaping_entities]
+      result
     end
   end
 end

--- a/sanitize-rails.gemspec
+++ b/sanitize-rails.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.0"
   s.add_dependency "sanitize", "~> 3.0"
+  s.add_dependency "htmlentities", "~> 4.3.3"
 end

--- a/test/sanitize_rails_engine_test.rb
+++ b/test/sanitize_rails_engine_test.rb
@@ -47,6 +47,20 @@ class SanitizeRailsEngineTest < Minitest::Test
     assert_instance_of ::ActiveSupport::SafeBuffer, new_string
   end
 
+  def test_clean_not_making_html_entities
+    string = %Q|<script>hello & world</script>|
+    @engine.configure(skip_escaping_entities: true)
+    @engine.clean! string
+    assert_equal string, "hello & world"
+  end
+
+  def test_clean_making_html_entities
+    string = %Q|<script>hello & world</script>|
+    @engine.configure(skip_escaping_entities: false)
+    @engine.clean! string
+    assert_equal string, "hello &amp; world"
+  end
+
   def test_clean_returns_blank_string_for_nil_input
     assert_equal '', @engine.clean(nil)
   end

--- a/test/sanitize_rails_engine_test.rb
+++ b/test/sanitize_rails_engine_test.rb
@@ -49,14 +49,14 @@ class SanitizeRailsEngineTest < Minitest::Test
 
   def test_clean_not_making_html_entities
     string = %Q|<script>hello & world</script>|
-    @engine.configure(skip_escaping_entities: true)
+    @engine.configure(escape_entities: false)
     @engine.clean! string
     assert_equal string, "hello & world"
   end
 
   def test_clean_making_html_entities
     string = %Q|<script>hello & world</script>|
-    @engine.configure(skip_escaping_entities: false)
+    @engine.configure(escape_entities: true)
     @engine.clean! string
     assert_equal string, "hello &amp; world"
   end


### PR DESCRIPTION
Hi, thanks for implementing this very useful gem! I recently needed to skip escaping html entities that is performed during sanitization. This might be helpful for other developers.